### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pynput==1.7.3
-pyscreenshot==0.5.1
+pyscreenshot>=3.0  # Use a newer version (tested with 3.1)
 sounddevice==0.4.3
-Pillow==9.3.0
+Pillow>=10.0.0  # Replace 9.3.0 with this


### PR DESCRIPTION
  * pyscreenshot==0.5.1 package uses outdated build configurations (use_2to3), which are incompatible with modern Python packaging tools

 * Pillow 9.3.0 is incompatible with Python 3.12 and lacks prebuilt Windows binaries for newer Python versions
 
**this request will fix this problem**